### PR TITLE
Fixed typo in 'node' and modified the command path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In a typical process, I start designing a machine from the specifications by dra
 
 # Usage
 ```bash
-mode ${yed2kingly filepath}/index.js file.graphml
+node ${yed2kingly filepath}/bin/yed2kingly file.graphml
 ```
 
 Running the converter produces two files, targeted at consumption in a browser and node.js environment:


### PR DESCRIPTION
Not sure if the `/bin/yed2Kingly` instead of `/index.js` will be necessary once the package is fixed, but right now it is the only thing that works.